### PR TITLE
Fix the issue that external account cannot start sagemaker workspace

### DIFF
--- a/main/solution/post-deployment/config/infra/cloudformation.yml
+++ b/main/solution/post-deployment/config/infra/cloudformation.yml
@@ -433,6 +433,7 @@ Resources:
                   - sagemaker:StopNotebookInstance
                   - sagemaker:StopNotebookInstance
                   - sagemaker:DeleteNotebookInstance
+                  - sagemaker:AddTags
                 Resource: !Sub 'arn:${AWS::Partition}:sagemaker:*:*:notebook-instance/basicnotebookinstance-*'
               - Effect: Allow
                 Action:


### PR DESCRIPTION
Issue #, if available:

Description of changes:
This issue should be caused by global repo change from v5.11 to v5.20

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [ yes] Have you successfully deployed to an AWS account with your changes?
- [ yes] Have you successfully deployed to an AWS China account with your changes?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully tested with your changes locally?
- [ ] If new dependencies have been added, have they been pinned to specific versions?
- [ ] Is this change also required on the AWS Solution version?
- [ ] Have you updated openapi.yaml if you made updates to API definition (including add, delete or update parameter and request data schema)?
- [ ] If you had to run manual tests, have you considered automating those tests by adding them to [end-to-end tests](../main/end-to-end-tests/README.md)?
- [ ] If you are updating the changelog and vending out a new release, have you updated versionNumber and versionDate in [.defaults.yml](../main/config/settings/.defaults.yml)

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
