### PR TITLE
change windows packer instance type back to t2

### DIFF
--- a/docs/docs/installation_guide/installation/ami-install.md
+++ b/docs/docs/installation_guide/installation/ami-install.md
@@ -23,4 +23,8 @@ In the Amazon EC2 service console, select AMI in the left-hand navigation. You s
 
 <img src={useBaseUrl('img/deployment/installation/AMI.png')} />
 
+:::note
+Because Hongkong region do not support t2 instance type, please follow this [guide](https://github.com/awslabs/service-workbench-on-aws-cn/discussions/76) to generate Windows AMI in Hongkong region.
+:::
+
 **Warning**: Each AMI build results in a new set of AMIs.

--- a/docs/docs/zh/installation_guide/installation/ami-install.md
+++ b/docs/docs/zh/installation_guide/installation/ami-install.md
@@ -23,4 +23,8 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 <img src={useBaseUrl('img/deployment/installation/AMI.png')} />
 
+:::note
+因为香港区域不支持 t2 的实例类型，请按照[guide](https://github.com/awslabs/service-workbench-on-aws-cn/discussions/76) 在香港区域创建AMI.
+:::
+
 **警告**:每个 AMI 构建都会产生一组新的 AMI。

--- a/main/solution/machine-images/config/infra/packer-ec2-windows-workspace.json
+++ b/main/solution/machine-images/config/infra/packer-ec2-windows-workspace.json
@@ -26,7 +26,7 @@
         "owners": ["amazon"],
         "most_recent": true
       },
-      "instance_type": "t3.medium",
+      "instance_type": "t2.medium",
       "communicator": "none",
       "ami_name": "{{user `ec2WindowsAmiPrefix`}}-{{timestamp}}"
     }


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Hongkong region do not support t2 instance type, for supporting hongkong region, can follow [workaround](https://github.com/awslabs/service-workbench-on-aws-cn/discussions/76) to generate Windows AMI.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [yes] Have you successfully deployed to an AWS account with your changes?
- [yes] Have you successfully deployed to an AWS China account with your changes?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully tested with your changes locally?
- [ ] If new dependencies have been added, have they been pinned to specific versions?
- [ ] Is this change also required on the AWS Solution version?
- [ ] Have you updated openapi.yaml if you made updates to API definition (including add, delete or update parameter and request data schema)?
- [ ] If you had to run manual tests, have you considered automating those tests by adding them to [end-to-end tests](../main/end-to-end-tests/README.md)?
- [ ] If you are updating the changelog and vending out a new release, have you updated versionNumber and versionDate in [.defaults.yml](../main/config/settings/.defaults.yml)

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
