### PR TITLE
add cache control header in http response

### DIFF
--- a/main/solution/infrastructure/config/infra/cloudformation.yml
+++ b/main/solution/infrastructure/config/infra/cloudformation.yml
@@ -202,10 +202,22 @@ Resources:
   # CloudFront
   # =============================================================================================
 
+  ResponseHeadersPolicy:
+    Type: AWS::CloudFront::ResponseHeadersPolicy
+    Properties:
+      ResponseHeadersPolicyConfig:
+        Name: Cache-Control-Response-Headers-Policy
+        Comment: Add Cache-Control header to responses
+        CustomHeadersConfig:
+          Items:
+            - Header: Cache-Control
+              Value: no-store, no-cache
+              Override: true
   WebsiteCloudFront:
     Type: AWS::CloudFront::Distribution
     DependsOn:
       - WebsiteBucket
+      - ResponseHeadersPolicy
     Properties:
       DistributionConfig:
         Comment: 'CloudFront Distribution pointing to ${self:custom.settings.websiteBucketName}'
@@ -251,6 +263,7 @@ Resources:
             Cookies:
               Forward: none
           ViewerProtocolPolicy: redirect-to-https
+          ResponseHeadersPolicyId: !Ref ResponseHeadersPolicy
         PriceClass: PriceClass_All
         Logging: !If
           - IsHongkongRegion


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Add Cache-Control header into response.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [yes ] Have you successfully deployed to an AWS account with your changes?
- [yes] Have you successfully deployed to an AWS China account with your changes?
- [yes] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully tested with your changes locally?
- [ ] If new dependencies have been added, have they been pinned to specific versions?
- [ ] Is this change also required on the AWS Solution version?
- [ ] Have you updated openapi.yaml if you made updates to API definition (including add, delete or update parameter and request data schema)?
- [ ] If you had to run manual tests, have you considered automating those tests by adding them to [end-to-end tests](../main/end-to-end-tests/README.md)?
- [ ] If you are updating the changelog and vending out a new release, have you updated versionNumber and versionDate in [.defaults.yml](../main/config/settings/.defaults.yml)

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
